### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
 npm run build && git add dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8434,7 +8434,7 @@
     "actions-toolkit": {
       "version": "git+ssh://git@github.com/nearform/actions-toolkit.git#42bc8890ee2df7d10db5cc8a7301ab03fc6c301b",
       "integrity": "sha512-aqoQ04EabVASf094ipfKyN8xUsxe6cWZrjbzzgFIEkS5cTUaumxwXyvQ3kuaV4lHQbijBQ9drJEI3P9RJ4DNHQ==",
-      "from": "actions-toolkit@github:nearform/actions-toolkit#42bc8890ee2df7d10db5cc8a7301ab03fc6c301b",
+      "from": "actions-toolkit@github:nearform/actions-toolkit",
       "requires": {
         "@actions/core": "^1.10.1"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "tap --node-arg=\"--loader=esmock\"",
-    "prepare": "husky install",
+    "prepare": "husky",
     "build": "ncc build src --license licenses.txt"
   },
   "repository": {


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)